### PR TITLE
RFC0014 Adaptive IP for services

### DIFF
--- a/pilot/pilot/relay.py
+++ b/pilot/pilot/relay.py
@@ -161,12 +161,10 @@ class RealMonitoringRelay(AbstractRelay):
     def _reboot(self):
         errors = []
         _config = self._config()
-        self._patience_micro = (
-            parse_option("patience.ms", int, 100, errors, **_config) * 1000.0
-        )
-        _pi_uri = parse_option(
-            "ras.master.uri", str, "tcp://192.168.1.32", errors, **_config
-        )
+        self._patience_micro = parse_option('patience.ms', int, 100, errors, **_config) * 1000.
+        _pi_uri = parse_option('ras.master.uri', str, 'tcp://192.168.1.32', errors, **_config)
+        _pi_uri = f"tcp://{_pi_uri}"
+        # Stopping the sockets that handle communication with the Pi
         if self._pi_client is not None:
             self._pi_client.quit()
         if self._pi_status is not None:

--- a/vehicles/rover/app.py
+++ b/vehicles/rover/app.py
@@ -118,12 +118,13 @@ class Platform(Configurable):
 
     def internal_start(self, **kwargs):
         errors = []
-        _master_uri = parse_option('ras.master.uri', str, 'tcp://192.168.1.32', errors, **kwargs)
-        _speed_factor = parse_option('ras.non.sensor.speed.factor', float, 0.50, errors, **kwargs)
+        _master_uri = parse_option("ras.master.uri", str, "192.168.1.32", errors, **kwargs)
+        _master_uri = "tcp://{}".format(_master_uri)
+        _speed_factor = parse_option("ras.non.sensor.speed.factor", float, 0.50, errors, **kwargs)
         self._odometer_config = (_master_uri, _speed_factor)
         self._start_odometer()
-        _gps_host = parse_option('gps.provider.host', str, '192.168.1.1', errors, **kwargs)
-        _gps_port = parse_option('gps.provider.port', str, '502', errors, **kwargs)
+        _gps_host = parse_option("gps.provider.host", str, "192.168.1.1", errors, **kwargs)
+        _gps_port = parse_option("gps.provider.port", str, "502", errors, **kwargs)
         self._gps = GpsPollerThread(_gps_host, _gps_port)
         self._gps.start()
         return errors

--- a/vehicles/rover/app.py
+++ b/vehicles/rover/app.py
@@ -3,16 +3,17 @@ import collections
 import glob
 import logging
 import os
+import re
 import shutil
+import subprocess
 
-from ConfigParser import SafeConfigParser
-
-from byodr.utils import Application, PeriodicCallTrace
-from byodr.utils import timestamp, Configurable
-from byodr.utils.ipc import JSONPublisher, ImagePublisher, LocalIPCServer, json_collector, ReceiverThread
+from byodr.utils import Application, Configurable, PeriodicCallTrace, timestamp
+from byodr.utils.ipc import (ImagePublisher, JSONPublisher, LocalIPCServer,
+                             ReceiverThread, json_collector)
 from byodr.utils.location import GeoTracker
-from byodr.utils.option import parse_option, hash_dict
-from core import GpsPollerThread, PTZCamera, ConfigurableImageGstSource
+from byodr.utils.option import hash_dict, parse_option
+from ConfigParser import SafeConfigParser
+from core import ConfigurableImageGstSource, GpsPollerThread, PTZCamera
 
 logger = logging.getLogger(__name__)
 log_format = '%(levelname)s: %(asctime)s %(filename)s %(funcName)s %(message)s'

--- a/vehicles/rover/app.py
+++ b/vehicles/rover/app.py
@@ -322,12 +322,7 @@ class RoverApplication(Application):
         self.teleop = None
         self.ipc_chatter = None
 
-    def _check_user_file(self):
-        # One user configuration file is optional and can be used to persist settings.
-        _candidates = glob.glob(os.path.join(self._config_dir, '*.ini'))
-        if len(_candidates) == 0:
-            shutil.copyfile('config.template', os.path.join(self._config_dir, 'config.ini'))
-            logger.info("Created a new user configuration file from template.")
+
 
     def _config(self):
         parser = SafeConfigParser()

--- a/vehicles/rover/app.py
+++ b/vehicles/rover/app.py
@@ -321,7 +321,7 @@ class RoverApplication(Application):
         self.pilot = None
         self.teleop = None
         self.ipc_chatter = None
-
+        self._config_files_class = ConfigFiles(self._config_dir)
 
 
     def _config(self):
@@ -341,7 +341,8 @@ class RoverApplication(Application):
             _hash = hash_dict(**_config)
             if _hash != self._config_hash:
                 self._config_hash = _hash
-                self._check_user_file()
+                self._config_files_class.check_configuration_files()
+                self._config_files_class.change_segment_config()
                 _restarted = self._handler.restart(**_config)
                 if _restarted:
                     self.ipc_server.register_start(self._handler.get_errors(), self._capabilities())

--- a/vehicles/rover/config.template
+++ b/vehicles/rover/config.template
@@ -1,5 +1,4 @@
 [camera]
-# front.camera.type = h264/udp
 front.camera.type = h264/rtsp
 front.camera.ip = 192.168.1.64
 rear.camera.type = h264/rtsp

--- a/vehicles/rover/config.template
+++ b/vehicles/rover/config.template
@@ -15,3 +15,6 @@ driver.throttle.direct.up.momentum = 0.020
 [vehicle]
 ras.driver.steering.offset = 0
 ras.driver.motor.scale = 2
+ras.master.uri = 192.168.1.32
+gps.provider.host = 192.168.1.1
+gps.provider.port = 502

--- a/vehicles/rover/core.py
+++ b/vehicles/rover/core.py
@@ -265,7 +265,7 @@ class GpsPollerThread(threading.Thread):
     https://pymodbus.readthedocs.io/en/v1.3.2/examples/modbus-payload.html
     """
 
-    def __init__(self, host='192.168.1.1', port='502'):
+    def __init__(self, host, port="502"):
         super(GpsPollerThread, self).__init__()
         self._host = host
         self._port = port


### PR DESCRIPTION
The current software has the IP hard-coded in it. This brought a problem when working on multi segment robots, having different releases of the same software just to change the IP in each. This feature will allow the software to work on any segment despite their IP (in the Jetson Nano and not the Respberry PI).
It has been tested on **5Earl**, **4Davide**, and **8Frank**.

Changes:
- Create new class `ConfigFiles` in the Vehicle (VEH) service that handles checking and modifying the config file.
- Change the default pi uri value in Pilot (PIL) to correspond to the newly added key in the confg.ini file.
- Change all the imports in all services to use the correct key from the config.ini file.

Important: Due to the current development of RFC12_ConfigurationFile, there is another `.ini` file called `robot_config.ini`. These two files have different purposes in the code. In the code of Teleop (TEL), the config file is mentioned to as "user config file" while it has been renamed now to "segment config file".

The `ConfigFiles` class deals only with the `config.ini` file, but it is supposed to be working with both the `config.ini` and `robot_config.ini` files. 

This feature was part of RFC12, but due to the stop of development (for changes in priority), it was necessary to move the adaptive IP feature to its own branch.