### PR TITLE
RFC0017 switching between FOL and manual mode

### DIFF
--- a/teleop/htm/static/JS/mobileController/mobileController_a_app.js
+++ b/teleop/htm/static/JS/mobileController/mobileController_a_app.js
@@ -5,7 +5,7 @@ import { handleDotMove, detectTriangle, handleTriangleMove, initializeWS, sendJS
 
 import CTRL_STAT from '/JS/mobileController/mobileController_z_state.js'; // Stands for control state
 import { redraw, app } from "/JS/mobileController/mobileController_d_pixi.js";
-import { toggleButton } from "/JS/mobileController/mobileController_b_following.js";
+import { toggleButtonHandler } from "/JS/mobileController/mobileController_b_following.js";
 
 // Initialize sending commands only once, instead of calling it each time we touch the triangles
 // The function would keep stacking, sending commands more often than 10 times a second
@@ -57,7 +57,7 @@ function startOperating(event) {
   app.stage.addChild(CTRL_STAT.cursorFollowingDot.graphics);
 
   // Hide the button when triangles are pressed
-  toggleButton.style.display = 'none';
+  toggleButtonHandler.setStyle('display', 'none');
 
   handleTriangleMove(event.touches[0].clientY);
 }
@@ -80,7 +80,7 @@ app.view.addEventListener('touchend', () => {
   }
 
   // Show the button again when touch ends
-  toggleButton.style.display = 'block';
+  toggleButtonHandler.setStyle('display', 'block');
 });
 
 function onTouchMove(event) {

--- a/teleop/htm/static/JS/mobileController/mobileController_a_app.js
+++ b/teleop/htm/static/JS/mobileController/mobileController_a_app.js
@@ -40,9 +40,12 @@ app.view.addEventListener('touchstart', (event) => {
         console.error("Connection lost with the robot. Please reconnect");
         break;
       default:
+        if (toggleButtonHandler.toggleButton.innerText === "Stop Following") {
+          toggleButtonHandler.sendSwitchFollowingRequest("Stop Following")
+        }
         startOperating(event)
         app.view.addEventListener('touchmove', onTouchMove);
-        // Arrow function to send the command through websocket 
+        // Arrow function to send the command through websocket
         break;
     }
   } else {

--- a/teleop/htm/static/JS/mobileController/mobileController_b_following.js
+++ b/teleop/htm/static/JS/mobileController/mobileController_b_following.js
@@ -1,22 +1,44 @@
-const toggleButton = document.getElementById('toggleButton');
+class ToggleButtonHandler {
+  constructor(buttonId) {
+    this.toggleButton = document.getElementById(buttonId);
+    this.toggleButton.addEventListener('click', () => {
+      this.handleButtonClick();
+    });
+  }
 
-toggleButton.addEventListener('click', function () {
-  const command = toggleButton.innerText === "Start Following" ? "Start Following" : "Stop Following";
 
-  fetch('/switch_following', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: `command=${encodeURIComponent(command)}`,
-  })
-    .then(response => response.json())
-    .then(data => console.log("Server response:", data))
-    .catch(error => console.error("Error sending command:", error));
+  handleButtonClick() {
+    // Determine the command based on the opposite of the current button text
+    let currentText = this.toggleButton.innerText;
+    this.sendSwitchFollowingRequest(currentText);
+  }
 
-      // Toggle button text and color
-  toggleButton.innerText = command === "Start Following" ? "Stop Following" : "Start Following";
-  toggleButton.style.backgroundColor = toggleButton.innerText === "Stop Following" ? "#ff6347" : "#67b96a";
-});
+  sendSwitchFollowingRequest(command) {
+    fetch('/switch_following', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `command=${encodeURIComponent(command)}`,
+    })
+      .then(response => response.json())
+      .then(data => {
+        console.log("Server response:", data);
+        this.toggleButtonAppearance(command);
+      })
+      .catch(error => console.error("Error sending command:", error));
+  }
 
-export { toggleButton };
+  toggleButtonAppearance(command) {
+    this.toggleButton.innerText = command === "Start Following" ? "Stop Following" : "Start Following";
+    this.toggleButton.style.backgroundColor = command === "Start Following" ? "#ff6347" : "#67b96a";
+  }
+
+
+
+// Usage
+const toggleButtonHandler = new ToggleButtonHandler('toggleButton');
+
+// If needed to export
+
+export { toggleButtonHandler };

--- a/teleop/htm/static/JS/mobileController/mobileController_b_following.js
+++ b/teleop/htm/static/JS/mobileController/mobileController_b_following.js
@@ -35,6 +35,22 @@ class ToggleButtonHandler {
   }
 
 
+  getAttribute(attributeName) {
+    return this.toggleButton.getAttribute(attributeName);
+  }
+
+  setAttribute(attributeName, value) {
+    this.toggleButton.setAttribute(attributeName, value);
+  }
+
+  getStyle(property) {
+    return this.toggleButton.style[property];
+  }
+
+  setStyle(property, value) {
+    this.toggleButton.style[property] = value;
+  }
+}
 
 // Usage
 const toggleButtonHandler = new ToggleButtonHandler('toggleButton');


### PR DESCRIPTION
The Following (FOL) mode keeps working even if the user is touching the active area on the mobile controller. This raises the problem if the user wants to change the immediate action of the robot in case of an accident. This feature will allow the user to switch from Following mode to normal mode as fast as possible.

What is changed:
- Wrap sending and changing the states of FOL button in class
- Implement the switch to manual mode from following if the user touches one of the two triangles (of active area) 