### PR TITLE
Veh - update docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,6 @@ services:
       context: .
       dockerfile: vehicles/rover/Dockerfile
     restart: always
-    command: ['python', 'app.py', '--name', 'vehicle']
     privileged: true # NvMedia device creation for omx decoder.
     network_mode: host
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
     cpuset: '1'
     build:
       context: .
-      dockerfile: vehicles/rover/rover_vehicle.dockerfile
+      dockerfile: vehicles/rover/Dockerfile
     restart: always
     command: ['python', 'app.py', '--name', 'vehicle']
     privileged: true # NvMedia device creation for omx decoder.

--- a/docker/focal-cp310-GST.dockerfile
+++ b/docker/focal-cp310-GST.dockerfile
@@ -1,0 +1,90 @@
+# docker buildx create --name mynewbuilder --use
+# docker buildx use mybuilder
+# docker buildx build --platform linux/arm64,linux/amd64 -t mwlvdev/jetson-nano-ubuntu:focal-cp310-GST . --push
+FROM ubuntu:focal-20240123
+
+# Set a non-interactive frontend
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libffi-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libssl-dev \    
+    zlib1g-dev \    
+    wget \
+    python-dev \
+    nano \
+    openssh-client \
+    lm-sensors \
+    software-properties-common
+
+# Download Python 3.10, compile it, and install
+RUN cd /tmp && \
+    wget https://www.python.org/ftp/python/3.10.0/Python-3.10.0.tgz && \
+    tar -xzf Python-3.10.0.tgz && \
+    cd Python-3.10.0 && \
+    ./configure --enable-optimizations && \
+    make -j 18 && \
+    make altinstall
+
+# Remove the Python source and temporary files
+RUN rm -rf /tmp/Python-3.10.0 /tmp/Python-3.10.0.tgz
+
+# Update pip for Python 3.10
+RUN python3.10 -m ensurepip && \
+    python3.10 -m pip install --upgrade pip
+
+# Set Python 3.10 as the default Python version
+RUN update-alternatives --install /usr/bin/python python /usr/local/bin/python3.10 1 && \
+    update-alternatives --set python /usr/local/bin/python3.10 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.10 1 && \
+    update-alternatives --set python3 /usr/local/bin/python3.10
+
+
+# Install additional dependencies for pygobject
+RUN apt-get install -y --no-install-recommends \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    gstreamer1.0-doc \
+    gstreamer1.0-tools \
+    gstreamer1.0-x \
+    gstreamer1.0-alsa \
+    gstreamer1.0-gl \
+    gstreamer1.0-gtk3 \
+    gstreamer1.0-qt5 \
+    python3-gi\
+    python-gi-dev\
+    python3-gst-1.0\
+    python-gobject\
+    libgtk-3-dev\
+    gstreamer1.0-pulseaudio \
+    libreadline-dev \
+    zlib1g-dev \
+    libgirepository1.0-dev build-essential \
+    libbz2-dev\
+    libssl-dev\ 
+    libsqlite3-dev\ 
+    curl\
+    llvm\ 
+    libncurses5-dev \
+    python3-gi-cairo\
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    libcairo2-dev\
+    gir1.2-gtk-3.0\
+    libgstreamer1.0-0 &&\
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Python packages using pip
+RUN python3.10 -m pip install cachetools jsoncomment requests pytest pymodbus geographiclib numpy zmq six configparser PyGObject
+

--- a/vehicles/rover/Dockerfile
+++ b/vehicles/rover/Dockerfile
@@ -1,0 +1,10 @@
+FROM mwlvdev/jetson-nano-ubuntu:focal-cp310-GST
+
+
+COPY ./common common/
+COPY ./vehicles/rover app/
+WORKDIR /app
+
+ENV PYTHONPATH "${PYTHONPATH}:/common"
+
+CMD ["python3.10", "app.py"]

--- a/vehicles/rover/app.py
+++ b/vehicles/rover/app.py
@@ -104,7 +104,9 @@ class Platform(Configurable):
                 except RasRemoteError as rre:
                     # After 5 seconds do a hard reboot of the remote connection.
                     if rre.timeout > 5000:
-                        logger.info("Hard odometer reboot at {} ms timeout.".format(rre.timeout))
+                        logger.info(
+                            f"Hard odometer reboot at {rre.timeout} ms timeout."
+                        )
                         self._quit_odometer()
                         self._start_odometer()
             return dict(latitude_geo=latitude,
@@ -124,6 +126,7 @@ class Platform(Configurable):
         _master_uri = parse_option("ras.master.uri", str, "192.168.1.32", errors, **kwargs)
         _master_uri = "tcp://{}".format(_master_uri)
         _speed_factor = parse_option("ras.non.sensor.speed.factor", float, 0.50, errors, **kwargs)
+        _master_uri = f"tcp://{_master_uri}"
         self._odometer_config = (_master_uri, _speed_factor)
         self._start_odometer()
         _gps_host = parse_option("gps.provider.host", str, "192.168.1.1", errors, **kwargs)
@@ -243,7 +246,7 @@ class ConfigFiles:
             if not os.path.exists(file_path):
                 template_file = template_files[file]
                 shutil.copyfile(template_file, file_path)
-                logger.info("Created {} from template.".format(file))
+                logger.info(f"Created {file} from template.")
 
             # Verify and add missing keys
             self._verify_and_add_missing_keys(file_path, template_files[file])
@@ -262,7 +265,9 @@ class ConfigFiles:
             for key, value in template_config.items(section):
                 if not config.has_option(section, key):
                     config.set(section, key, value)
-                    logger.info("Added missing key '{}' in section '[{}]' to {}".format(key, section, ini_file))
+                    logger.info(
+                        f"Added missing key '{key}' in section '[{section}]' to {ini_file}"
+                    )
 
         # Write changes to the ini file
         with open(ini_file, "w") as configfile:
@@ -308,9 +313,9 @@ class ConfigFiles:
 
             # Print changes made
             if changes_made_in_file:
-                logger.info("Updated {} with new ip address".format(file))
+                logger.info("Updated {file} with new ip address")
             else:
-                logger.info("No changes needed for {}.".format(file))
+                logger.info(f"No changes needed for {file}.")
 
 
 class RoverApplication(Application):
@@ -351,7 +356,7 @@ class RoverApplication(Application):
                     self.ipc_server.register_start(self._handler.get_errors(), self._capabilities())
                     _frequency = self._handler.get_process_frequency()
                     self.set_hz(_frequency)
-                    self.logger.info("Processing at {} Hz.".format(_frequency))
+                    self.logger.info(f"Processing at {_frequency} Hz.")
 
     def finish(self):
         self._handler.quit()

--- a/vehicles/rover/app.py
+++ b/vehicles/rover/app.py
@@ -12,7 +12,7 @@ from byodr.utils.ipc import (ImagePublisher, JSONPublisher, LocalIPCServer,
                              ReceiverThread, json_collector)
 from byodr.utils.location import GeoTracker
 from byodr.utils.option import hash_dict, parse_option
-from ConfigParser import SafeConfigParser
+from configparser import ConfigParser as SafeConfigParser
 from core import ConfigurableImageGstSource, GpsPollerThread, PTZCamera
 
 logger = logging.getLogger(__name__)

--- a/vehicles/rover/app.py
+++ b/vehicles/rover/app.py
@@ -126,7 +126,6 @@ class Platform(Configurable):
         _master_uri = parse_option("ras.master.uri", str, "192.168.1.32", errors, **kwargs)
         _master_uri = "tcp://{}".format(_master_uri)
         _speed_factor = parse_option("ras.non.sensor.speed.factor", float, 0.50, errors, **kwargs)
-        _master_uri = f"tcp://{_master_uri}"
         self._odometer_config = (_master_uri, _speed_factor)
         self._start_odometer()
         _gps_host = parse_option("gps.provider.host", str, "192.168.1.1", errors, **kwargs)

--- a/vehicles/rover/app.py
+++ b/vehicles/rover/app.py
@@ -16,7 +16,9 @@ from ConfigParser import SafeConfigParser
 from core import ConfigurableImageGstSource, GpsPollerThread, PTZCamera
 
 logger = logging.getLogger(__name__)
-log_format = '%(levelname)s: %(asctime)s %(filename)s %(funcName)s %(message)s'
+log_format = (
+    "%(levelname)s: %(asctime)s %(filename)s %(funcName)s %(lineno)d %(message)s"
+)
 
 
 class RasRemoteError(IOError):

--- a/vehicles/rover/core.py
+++ b/vehicles/rover/core.py
@@ -73,9 +73,9 @@ class ConfigurableImageGstSource(Configurable):
         self._close()
         _errors = []
         _type = parse_option(self._name + '.camera.type', str, 'h264/rtsp', errors=_errors, **kwargs)
-            self._name + ".camera.type", str, "h264/rtsp", errors=_errors, **kwargs
-        )
         assert _type in gst_commands.keys(), "Unrecognized camera type '{_type}'."
+        framerate = 25 if self._name == 'front' else 12
+        framerate = (parse_option(self._name + '.camera.framerate', int, framerate, errors=_errors, **kwargs))
         out_width, out_height = [int(x) for x in parse_option(self._name + '.camera.shape', str, '320x240',
                                                               errors=_errors, **kwargs).split('x')]
         if _type == 'h264/rtsp':

--- a/vehicles/rover/core.py
+++ b/vehicles/rover/core.py
@@ -74,9 +74,9 @@ class ConfigurableImageGstSource(Configurable):
         self._close()
         _errors = []
         _type = parse_option(self._name + '.camera.type', str, 'h264/rtsp', errors=_errors, **kwargs)
-        assert _type in gst_commands.keys(), "Unrecognized camera type '{}'.".format(_type)
-        framerate = 25 if self._name == 'front' else 12
-        framerate = (parse_option(self._name + '.camera.framerate', int, framerate, errors=_errors, **kwargs))
+            self._name + ".camera.type", str, "h264/rtsp", errors=_errors, **kwargs
+        )
+        assert _type in gst_commands.keys(), "Unrecognized camera type '{_type}'."
         out_width, out_height = [int(x) for x in parse_option(self._name + '.camera.shape', str, '320x240',
                                                               errors=_errors, **kwargs).split('x')]
         if _type == 'h264/rtsp':
@@ -103,7 +103,7 @@ class ConfigurableImageGstSource(Configurable):
         _command = gst_commands.get(_type).format(**config)
         self._sink = create_image_source(self._name, shape=self._shape, command=_command)
         self._sink.add_listener(self._publish)
-        logger.info("Gst '{}' command={}".format(self._name, _command))
+        logger.info(f"Gst '{self._name}' command={ _command}")
         return _errors
 
 
@@ -156,7 +156,8 @@ class CameraPtzThread(threading.Thread):
         elif operation != prev:
             ret = self._run(operation)
             if ret and ret.status_code != 200:
-                logger.warning("Got status {} on operation {}.".format(ret.status_code, operation))
+                logger.warning(
+                    f"Got status {ret.status_code} on operation {operation}.")
 
     def _run(self, operation):
         ret = None
@@ -243,6 +244,7 @@ class PTZCamera(Configurable):
             _port = 80 if _protocol == 'http' else 443
             _url = '{protocol}://{server}:{port}{path}'.format(**dict(protocol=_protocol, server=_server, port=_port, path=_path))
             logger.info("PTZ camera url={}.".format(_url))
+            logger.info(f"PTZ camera url={_url}.")
             if self._worker is None:
                 self._worker = CameraPtzThread(_url, _user, _password, speed=_speed, flip=_flipcode)
                 self._worker.start()

--- a/vehicles/rover/core.py
+++ b/vehicles/rover/core.py
@@ -1,10 +1,10 @@
 import collections
 import logging
 import multiprocessing
+import queue
 import threading
 import time
 
-import Queue
 import requests
 from pymodbus.client.sync import ModbusTcpClient
 from pymodbus.constants import Endian

--- a/vehicles/rover/core.py
+++ b/vehicles/rover/core.py
@@ -125,7 +125,7 @@ class CameraPtzThread(threading.Thread):
         </PTZData>
         """
         self.set_auth(user, password)
-        self._queue = Queue.Queue(maxsize=1)
+        self._queue = queue.Queue(maxsize=1)
         self._previous = (0, 0)
 
     def set_url(self, url):
@@ -181,7 +181,7 @@ class CameraPtzThread(threading.Thread):
     def add(self, command):
         try:
             self._queue.put_nowait(command)
-        except Queue.Full:
+        except queue.Full:
             pass
 
     def quit(self):
@@ -200,7 +200,7 @@ class CameraPtzThread(threading.Thread):
                     elif 'pan' in cmd and 'tilt' in cmd:
                         operation = (self._norm(cmd.get('pan')) * self._flip[0], self._norm(cmd.get('tilt')) * self._flip[1])
                     self._perform(operation)
-            except Queue.Empty:
+            except queue.Empty:
                 pass
             except IOError as e:
                 # E.g. a requests ConnectionError to the ip camera.

--- a/vehicles/rover/core.py
+++ b/vehicles/rover/core.py
@@ -6,14 +6,13 @@ import threading
 import time
 
 import requests
-from pymodbus.client.sync import ModbusTcpClient
-from pymodbus.constants import Endian
-from pymodbus.payload import BinaryPayloadDecoder
-from requests.auth import HTTPDigestAuth
-
 from byodr.utils import Configurable
 from byodr.utils.option import parse_option
 from byodr.utils.video import create_image_source
+from pymodbus.client import ModbusTcpClient
+from pymodbus.constants import Endian
+from pymodbus.payload import BinaryPayloadDecoder
+from requests.auth import HTTPDigestAuth
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Vehicle (VEH) service is the only service that is running python 2x (2.7). This resulted in a slow progress in development due to not using some libraries that require python 3x. 


Changes:
- Created new docker image
- Base image is using Ubuntu Focal instead of bionic ( because pyGObject couldn't be installed through python package manager due to low version of GCC for bionic version)
- Using python 3.10 as default python
- Changed the logger print to include line number of print message
- Updated from `Queue` to `queue`
- Updated from `SafeConfigParser` to `ConfigParser`

It has been tested on 5Earl

Note: There is an ongoing problem with Endian.Big library that does the modbus communication with the RUT955. It prints `Big` in the console because (I assume) there isn't any data coming back from the GPS when it cannot get the signal. 
This problem is out of scope so I didn't fix it here. The fix would be send the data to TEL only if there is a value returned from the modbus  