### PR TITLE
(fix)motor controller stutter

### DIFF
--- a/pilot/pilot/app.py
+++ b/pilot/pilot/app.py
@@ -37,8 +37,8 @@ def _interrupt():
 
 
 class PilotApplication(Application):
-    def __init__(self, event, processor, relay, config_dir=os.getcwd()):
-        super(PilotApplication, self).__init__(quit_event=event)
+    def __init__(self, event, processor, relay, config_dir=os.getcwd(), hz=100):
+        super(PilotApplication, self).__init__(quit_event=event, run_hz=hz)
         self._config_dir = config_dir
         self._processor = processor
         self._monitor = None

--- a/raspi/ras/servos.py
+++ b/raspi/ras/servos.py
@@ -374,7 +374,7 @@ class MainApplication(Application):
         self._integrity = MessageStreamProtocol(max_age_ms=100, max_delay_ms=100)
         self._cmd_history = CommandHistory(hz=hz)
         self._config_queue = collections.deque(maxlen=1)
-        self._drive_queue = collections.deque(maxlen=1)
+        self._drive_queue = collections.deque(maxlen=4)
         self._chassis = None
         self.platform = None
         self.publisher = None

--- a/raspi/ras/servos.py
+++ b/raspi/ras/servos.py
@@ -366,7 +366,7 @@ class DualVescDriver(AbstractDriver):
 
 
 class MainApplication(Application):
-    def __init__(self, event, config_file, relay, hz=50, test_mode=False):
+    def __init__(self, event, config_file, relay, hz, test_mode=False):
         super(MainApplication, self).__init__(run_hz=hz, quit_event=event)
         self.test_mode = test_mode
         self.config_file_dir = config_file
@@ -375,6 +375,8 @@ class MainApplication(Application):
         self._cmd_history = CommandHistory(hz=hz)
         self._config_queue = collections.deque(maxlen=1)
         self._drive_queue = collections.deque(maxlen=4)
+        self._last_drive_command = None  # Store the last drive command
+
         self._chassis = None
         self.platform = None
         self.publisher = None
@@ -446,7 +448,19 @@ class MainApplication(Application):
         return self._config_queue.popleft() if bool(self._config_queue) else None
 
     def _pop_drive(self):
-        return self._drive_queue.popleft() if bool(self._drive_queue) else None
+        """Get one command from one end of the drive queue"""
+        # This case happens when booting for the first time and PIL didn't send anything yet
+        if not self._drive_queue:
+            if self._last_drive_command:
+                # If the queue is empty and there's a last known command, return it instead of None
+                return self._last_drive_command
+            else:
+                # A default command if no commands have ever been received
+                return {"steering": 0.0, "throttle": 0.0, "reverse": 0, "wakeup": 0}
+        else:
+            # Pop the command from the queue and update the last known command
+            self._last_drive_command = self._drive_queue.popleft()
+            return self._last_drive_command
 
     def _on_message(self, message):
         self._integrity.on_message(message.get("time"))
@@ -467,11 +481,12 @@ class MainApplication(Application):
             return
 
         c_config, c_drive = self._pop_config(), self._pop_drive()
+        # print(c_drive)
         self._chassis.set_configuration(c_config)
 
-        v_steering = 0 if c_drive is None else c_drive.get('steering', 0)
-        v_throttle = 0 if c_drive is None else c_drive.get('throttle', 0)
-        v_wakeup = False if c_drive is None else bool(c_drive.get('wakeup'))
+        v_steering = 0 if c_drive is None else c_drive.get("steering", 0)
+        v_throttle = 0 if c_drive is None else c_drive.get("throttle", 0)
+        v_wakeup = False if c_drive is None else bool(c_drive.get("wakeup"))
 
         self._cmd_history.touch(steering=v_steering, throttle=v_throttle, wakeup=v_wakeup)
         if self._cmd_history.is_missing():


### PR DESCRIPTION
The connection we have now is from the Jetson Nano to the Pi back and forth. Pilot service is the one that communicates with the pi service, RAS ( for servos in motor controller). Pilot (PIL) collects the data from different IPC sockets of services like rosnode (ROS), inference (INF), and vehicle (VEH), then decides which ones to send from PIL under its name as unified from the side of nano.

Pi receives the message from PIL service and then classifies it as one of two options, either the ` message.get("method") == "ras/driver/config"` or anything else, which is method `ras/servo/drive`. Config ones are sent at the beginning when the operator is on normal controller page before activating the motors, then later it starts sending empty json `{"steering": 0.0, "throttle": 0.0, "reverse": 0, "wakeup": 0}`.

The idea is that to keep the connection alive between nano and pi (as a heartbeat pulse), PIL makes the command (from different services) then sends it to RAS and RAS replies back with a json of the velocity for the velocity of current wheels back to PIL ( which is what you see on tel service in normal controller page).

The stutter problem would happen because, as RAS is always sending something back to PIL service from the dequeue, sometimes, this dequeue is empty. The fix I did was keeping always a last command in this dequeue before popping the last command from it.

This fix was important, not just to fix the stutter, but also because I had problems when training INF and trying to collect data.

It has been tested on 5Earl on local mode. No release on Balena has been made yet.